### PR TITLE
fix: resolve PHP 8.4 deprecation warnings

### DIFF
--- a/src/PhpWord/Media.php
+++ b/src/PhpWord/Media.php
@@ -47,7 +47,7 @@ class Media
      *
      * @return int
      */
-    public static function addElement($container, $mediaType, $source, Image $image = null)
+    public static function addElement($container, $mediaType, $source, ?Image $image = null)
     {
         // Assign unique media Id and initiate media container if none exists
         $mediaId = md5($container . $source);
@@ -214,7 +214,7 @@ class Media
      *
      * @codeCoverageIgnore
      */
-    public static function addSectionMediaElement($src, $type, Image $image = null)
+    public static function addSectionMediaElement($src, $type, ?Image $image = null)
     {
         return self::addElement('section', $type, $src, $image);
     }
@@ -280,7 +280,7 @@ class Media
      *
      * @codeCoverageIgnore
      */
-    public static function addHeaderMediaElement($headerCount, $src, Image $image = null)
+    public static function addHeaderMediaElement($headerCount, $src, ?Image $image = null)
     {
         return self::addElement("header{$headerCount}", 'image', $src, $image);
     }
@@ -328,7 +328,7 @@ class Media
      *
      * @codeCoverageIgnore
      */
-    public static function addFooterMediaElement($footerCount, $src, Image $image = null)
+    public static function addFooterMediaElement($footerCount, $src, ?Image $image = null)
     {
         return self::addElement("footer{$footerCount}", 'image', $src, $image);
     }

--- a/src/PhpWord/Shared/XMLWriter.php
+++ b/src/PhpWord/Shared/XMLWriter.php
@@ -171,7 +171,7 @@ class XMLWriter extends \XMLWriter
      * @param mixed $value
      * @return bool
      */
-    public function writeAttribute($name, $value)
+    public function writeAttribute($name, $value): bool
     {
         if (is_float($value)) {
             $value = json_encode($value);

--- a/src/PhpWord/Style/Language.php
+++ b/src/PhpWord/Style/Language.php
@@ -232,7 +232,7 @@ final class Language extends AbstractStyle
             $locale = str_replace('_', '-', $locale);
         }
 
-        if (strlen($locale) === 2) {
+        if ($locale !== null && strlen($locale) === 2) {
             return strtolower($locale) . '-' . strtoupper($locale);
         }
 


### PR DESCRIPTION
- Use explicit nullable types for Image parameters in Media methods
- Add bool return type to XMLWriter::writeAttribute() to match parent
- Guard strlen() call against null in Language::validateLocale()
